### PR TITLE
Move error codes from client.go to error.go

### DIFF
--- a/jrpc/client.go
+++ b/jrpc/client.go
@@ -11,12 +11,6 @@ import (
 	"net"
 )
 
-const (
-	ParseError       = -32700
-	InternalError    = -32603
-	UnsupportedError = -32001 // Feature not implemented yet.
-)
-
 // ClientDispatcher handles client connections parsing their requests and dispatching messages
 // and batch requests to their correct callback.
 type ClientDispatcher interface {

--- a/jrpc/error.go
+++ b/jrpc/error.go
@@ -1,6 +1,9 @@
 package jrpc
 
 const (
-	MethodNotFound = -32601
-	InvalidParams  = -32602
+	UnsupportedError = -32001 // Feature not implemented yet.
+	MethodNotFound   = -32601
+	InvalidParams    = -32602
+	InternalError    = -32603
+	ParseError       = -32700
 )


### PR DESCRIPTION
## Changes
* Move `ParseError`,  `InteralError` and `UnsupportedError` from `client.go` to `error.go`