### PR TITLE
Feat/create callbacks

### DIFF
--- a/jrpc/callback.go
+++ b/jrpc/callback.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"reflect"
+	"sync"
 )
 
 // ParametersParseError indicates an error on parameters' json parsing.
@@ -46,20 +47,58 @@ type CallbackHandler interface {
 // DefaultHandler is the default implementation for CallbackHandler.
 type DefaultHandler struct {
 	logger   *slog.Logger
-	registry MethodRegistry
+	registry CallbackRegistry
 }
 
 // NewCallbackHandler creates a new DefaultHandler.
-func NewCallbackHandler(logger *slog.Logger, registry MethodRegistry) DefaultHandler {
+func NewCallbackHandler(logger *slog.Logger, registry CallbackRegistry) DefaultHandler {
 	return DefaultHandler{logger: logger, registry: registry}
+}
+
+func (ch *DefaultHandler) HandleBatch(ctx context.Context, msgs []Message) []Message {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan Message, len(msgs))
+
+	// It's called wg for convention, so ignore warning.
+	//nolint:varnamelen
+	var wg sync.WaitGroup
+
+	wg.Add(len(msgs))
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for _, msg := range msgs {
+		go func() {
+			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
+			defer wg.Done()
+
+			results <- ch.HandleMsg(ctx, msg)
+		}()
+	}
+
+	out := make([]Message, len(msgs))
+	i := 0
+
+	for result := range results {
+		out[i] = result
+		i++
+	}
+
+	return out
 }
 
 // HandleMsg handles a single message.
 func (ch *DefaultHandler) HandleMsg(ctx context.Context, msg Message) Message {
-	method, ok := ch.registry.GetByName(msg.Method) // Get the requested method.
+	callback, argsType, ok := ch.registry.GetByName(msg.Method) // Get the requested method.
 	// Check if exists
 	if !ok {
-		ch.logger.Warn("method could not be found", slog.String("method", method.Type().Name()))
+		ch.logger.Warn("method could not be found", slog.String("method", msg.Method))
 
 		return errorMessage(MethodNotFound, fmt.Sprintf("%v: not found", msg.Method), nil)
 	}
@@ -67,7 +106,7 @@ func (ch *DefaultHandler) HandleMsg(ctx context.Context, msg Message) Message {
 	// Convert msg.Params from json.RawMessage to an array of reflect.Value.
 	params, err := parseParams(
 		msg.Params,
-		method.Type().In(0), // The method's first argument should be an argument struct.
+		argsType,
 	)
 	if err != nil {
 		ch.logger.Error("could not parse params", slog.Any("error", err))
@@ -88,16 +127,34 @@ func (ch *DefaultHandler) HandleMsg(ctx context.Context, msg Message) Message {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	result := make(chan any) // Procedure result
+	resultCh := make(chan any, 1) // Procedure result
+	errCh := make(chan *ProcedureError, 1)
 
 	go func() {
-		result <- method.Call(params)[0].Interface() // Execute procedure call in a new goroutine
+		res, err := callback(params)
+		resultCh <- res
+		errCh <- err
 	}()
 
 	select {
 	case <-ctx.Done(): // If context is done, stop procedure.
 		return errorMessage(InternalError, "server stopped", nil)
-	case res := <-result:
+	case res := <-resultCh:
+		if err := <-errCh; err != nil {
+			return Message{
+				JSONRPC: jsonrpc,
+				ID:      msg.ID,
+				Error: &Error{
+					Code:    err.code,
+					Message: err.msg,
+					Data:    err.data,
+				},
+				Method: "",
+				Params: nil,
+				Result: nil,
+			}
+		}
+
 		resp := Message{
 			JSONRPC: jsonrpc,
 			ID:      msg.ID,

--- a/jrpc/callback_test.go
+++ b/jrpc/callback_test.go
@@ -18,14 +18,30 @@ type ArgsType struct {
 	MySecondField *int
 }
 
-func (mr *MockRegistry) GetByName(_ string) (reflect.Value, bool) {
-	return reflect.ValueOf(func(args ArgsType) int {
-		if args.MyFirstField == nil || args.MySecondField == nil {
-			return 0
+const (
+	failMethod       = "fail"
+	userDefinedError = 1
+)
+
+func (mr *MockRegistry) GetByName(method string) (jrpc.Callback, reflect.Type, bool) {
+	if method == failMethod {
+		return func(params []reflect.Value) (any, *jrpc.ProcedureError) {
+			return nil, jrpc.NewError(userDefinedError, "user defined error", nil)
+		}, reflect.TypeFor[ArgsType](), true
+	}
+
+	return func(params []reflect.Value) (any, *jrpc.ProcedureError) {
+		args, ok := params[0].Interface().(ArgsType)
+		if !ok {
+			return nil, jrpc.NewError(2, "could not get args", nil)
 		}
 
-		return *args.MyFirstField - *args.MySecondField
-	}), true
+		if args.MyFirstField == nil || args.MySecondField == nil {
+			return 0, nil
+		}
+
+		return *args.MyFirstField - *args.MySecondField, nil
+	}, reflect.TypeFor[ArgsType](), true
 }
 
 func NewHandler(t *testing.T) jrpc.DefaultHandler {
@@ -371,5 +387,24 @@ func TestDefaultHandler_HandleMsgShouldReturnAnErrorIfServerStops(t *testing.T) 
 
 	if resp.Error == nil || resp.Error.Code != jrpc.InternalError {
 		t.Errorf("server should return an internal error on stop: got %v", resp.Error)
+	}
+}
+
+func TestDefaultHandler_HandleMsgShouldReturnUserDefinedErrors(t *testing.T) {
+	t.Parallel()
+
+	handler := NewHandler(t)
+
+	id := 2
+
+	resp := handler.HandleMsg(context.Background(), jrpc.Message{
+		JSONRPC: jsonrpc,
+		ID:      &id,
+		Method:  failMethod,
+		Params:  []byte("[2, 3]"),
+	})
+
+	if resp.Error == nil || resp.Error.Code != userDefinedError {
+		t.Errorf("handler should return user defined error: got %v", resp.Error)
 	}
 }

--- a/jrpc/error.go
+++ b/jrpc/error.go
@@ -1,9 +1,30 @@
 package jrpc
 
+import "fmt"
+
 const (
 	UnsupportedError = -32001 // Feature not implemented yet.
+	UnexpectedError  = -32002
 	MethodNotFound   = -32601
 	InvalidParams    = -32602
 	InternalError    = -32603
 	ParseError       = -32700
 )
+
+type ProcedureError struct {
+	code int
+	msg  string
+	data any
+}
+
+func (pe *ProcedureError) Error() string {
+	return fmt.Sprintf("%v: %v", pe.code, pe.msg)
+}
+
+func NewError(code int, msg string, data any) *ProcedureError {
+	return &ProcedureError{
+		code: code,
+		msg:  msg,
+		data: data,
+	}
+}

--- a/jrpc/method.go
+++ b/jrpc/method.go
@@ -1,7 +1,0 @@
-package jrpc
-
-import "reflect"
-
-type MethodRegistry interface {
-	GetByName(name string) (reflect.Value, bool)
-}

--- a/jrpc/registry.go
+++ b/jrpc/registry.go
@@ -1,0 +1,14 @@
+package jrpc
+
+import (
+	"reflect"
+)
+
+// Callback signature. For methods that don't return one or both a value and an error the
+// missing return values always will be nil.
+type Callback func(params []reflect.Value) (any, *ProcedureError)
+
+// CallbackRegistry allows getting registered callbacks by name.
+type CallbackRegistry interface {
+	GetByName(name string) (callback Callback, argsType reflect.Type, found bool)
+}


### PR DESCRIPTION
## Changes
* Create callback signature `func([]reflect.Value) (any, error)`.
* Change `MethodRegistry` name to `CallbackRegistry`.
* Change `CallbackRegistry.GetByName` signature to return a callback.
* Handle user defined errors.
* Move contents from `method.go` to `registry.go`