### PR TITLE
Make NewCallbackHandler return a pointer

### DIFF
--- a/jrpc/callback.go
+++ b/jrpc/callback.go
@@ -51,8 +51,8 @@ type DefaultHandler struct {
 }
 
 // NewCallbackHandler creates a new DefaultHandler.
-func NewCallbackHandler(logger *slog.Logger, registry CallbackRegistry) DefaultHandler {
-	return DefaultHandler{logger: logger, registry: registry}
+func NewCallbackHandler(logger *slog.Logger, registry CallbackRegistry) *DefaultHandler {
+	return &DefaultHandler{logger: logger, registry: registry}
 }
 
 func (ch *DefaultHandler) HandleBatch(ctx context.Context, msgs []Message) []Message {

--- a/jrpc/callback_test.go
+++ b/jrpc/callback_test.go
@@ -44,7 +44,7 @@ func (mr *MockRegistry) GetByName(method string) (jrpc.Callback, reflect.Type, b
 	}, reflect.TypeFor[ArgsType](), true
 }
 
-func NewHandler(t *testing.T) jrpc.DefaultHandler {
+func NewHandler(t *testing.T) *jrpc.DefaultHandler {
 	t.Helper()
 
 	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))


### PR DESCRIPTION
## Changes
* Make `NewCallbackHandler` return a pointer.

`NewCallbackHandler` must return an instance of `CallbackHandler`, so `NewCallbackHandler` must return a pointer to `DefaultHandler`.