### PR TITLE
Feat/server conn

### DIFF
--- a/response.go
+++ b/response.go
@@ -4,10 +4,10 @@ import "encoding/json"
 
 // Response represents a JSON-RPC response.
 type Response struct {
-	JSONRPC string      `json:"jsonrpc,omitempty"` // Must be "2.0".
-	Result  any         `json:"result,omitempty"`  // The result of the call, must not be nil on success.
-	Error   *Error      `json:"error,omitempty"`   // The error of the call, must not be nil on failure.
-	ID      json.Number `json:"id"`                // The request identifier, must match the response identifier.
+	JSONRPC string       `json:"jsonrpc,omitempty"` // Must be "2.0".
+	Result  any          `json:"result,omitempty"`  // The result of the call, must not be nil on success.
+	Error   *Error       `json:"error,omitempty"`   // The error of the call, must not be nil on failure.
+	ID      *json.Number `json:"id"`                // The request identifier, must match the response identifier.
 }
 
 // Error represents a JSON-RPC error.

--- a/server.go
+++ b/server.go
@@ -69,7 +69,7 @@ func (s *Server) ServeConn(ctx context.Context, conn io.ReadWriteCloser) {
 			var msg json.RawMessage // Raw JSON-RPC message.
 
 			if err := dec.Decode(&msg); err == io.EOF { // Connection closed.
-				break
+				return
 			} else if err != nil { // Decode error.
 				s.errorLog("failed to decode message: %v", err)
 				continue

--- a/server.go
+++ b/server.go
@@ -5,7 +5,10 @@ import (
 	"net/http"
 )
 
-const JsonRPCVersion = "2.0" // Must be "2.0" for all JSON-RPC 2.0 messages.
+const (
+	JsonRPCVersion = "2.0" // Must be "2.0" for all JSON-RPC 2.0 messages.
+	ParseError     = -32700
+)
 
 type Server struct {
 	errorLog func(string, ...any) // Log errors.

--- a/server.go
+++ b/server.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 )
 
-type Server struct{}
+type Server struct {
+	errorLog func(string, ...any) // Log errors.
+}
 
-func NewServer() *Server {
-	return &Server{}
+func NewServer(errorLog func(string, ...any)) *Server {
+	return &Server{errorLog: errorLog}
 }
 
 func (s *Server) Register(method string, handler any) {

--- a/server.go
+++ b/server.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 )
 
+const JsonRPCVersion = "2.0" // Must be "2.0" for all JSON-RPC 2.0 messages.
+
 type Server struct {
 	errorLog func(string, ...any) // Log errors.
 }

--- a/server.go
+++ b/server.go
@@ -44,6 +44,7 @@ func (s *Server) Accept(ctx context.Context, lis net.Listener) error {
 }
 
 func (s *Server) ServeConn(ctx context.Context, conn net.Conn) {
+func (s *Server) ServeConn(ctx context.Context, conn io.ReadWriteCloser) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 }

--- a/server.go
+++ b/server.go
@@ -20,6 +20,10 @@ type Server struct {
 }
 
 func NewServer(errorLog func(string, ...any)) *Server {
+	if errorLog == nil {
+		errorLog = func(string, ...any) {}
+	}
+
 	return &Server{errorLog: errorLog}
 }
 

--- a/server.go
+++ b/server.go
@@ -52,6 +52,24 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	panic("not implemented")
 }
 
+// parseError returns a JSON-RPC response with a parse error.
+func parseError(err error) *Response {
+	data := ""
+
+	if err != nil {
+		data = err.Error()
+	}
+
+	return &Response{
+		JSONRPC: JsonRPCVersion,
+		Error: &Error{
+			Code:    ParseError,
+			Message: "Parse error",
+			Data:    data,
+		},
+	}
+}
+
 // handleBatchRPC handles concurrently a batch of requests, the order of the responses can be different from the order of the requests,
 // the response's ID must be used to match the request's ID.
 func (s *Server) handleBatchRPC(msg *json.RawMessage) ([]Response, error) {

--- a/server.go
+++ b/server.go
@@ -75,8 +75,12 @@ func (s *Server) ServeConn(ctx context.Context, conn io.ReadWriteCloser) {
 				continue
 			}
 
-			firstByte := bytes.TrimLeft(msg, " \t\n")[0] // First non-whitespace byte.
-
+			trimmedMsg := bytes.TrimLeft(msg, " \t\n") // Trim leading whitespace.
+			if len(trimmedMsg) == 0 {
+				s.errorLog("empty message received")
+				continue
+			}
+			firstByte := trimmedMsg[0] // First non-whitespace byte.
 			if firstByte == '[' { // Batch request.
 				res, err := s.handleBatchRPC(&msg)
 				if err != nil {

--- a/server_test.go
+++ b/server_test.go
@@ -1,0 +1,198 @@
+package jrpc_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/kytnacode/go-jrpc"
+)
+
+// mock io.ReadWriteCloser.
+type ioReadWriteCloser struct {
+	io.Reader
+	io.Writer
+
+	closed bool
+}
+
+func (rwc *ioReadWriteCloser) Close() error {
+	rwc.closed = true
+
+	return nil
+}
+
+func newIOReadWriteCloser(r io.Reader, w io.Writer) *ioReadWriteCloser {
+	return &ioReadWriteCloser{r, w, false}
+}
+
+func TestServer_ServeConnInvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	const invalidJSON = `{"jsonrpc": "2.0", "method": "foo", "params": "bar", "id": 1` // missing closing brace
+
+	r, w := io.Pipe() // Create a pipe to simulate a connection.
+
+	conn := newIOReadWriteCloser(strings.NewReader(invalidJSON), w)
+
+	testSucceedc := make(chan struct{}) // Expect request to fail
+	testFailc := make(chan error)       // Test will fail if the request succeeds or an error occurs.
+
+	errorLog := func(string, ...any) {
+		testSucceedc <- struct{}{} // Error log should be called.
+	}
+
+	s := jrpc.NewServer(errorLog)
+
+	go s.ServeConn(context.Background(), conn)
+
+	go func() {
+		if err := json.NewDecoder(r).Decode(&struct{}{}); err != nil {
+			testFailc <- err
+		}
+	}()
+
+	select {
+	case <-testSucceedc:
+	case err := <-testFailc:
+		t.Fatalf("expected invalid JSON: %v", err)
+	}
+}
+
+func TestServer_ServeConnValidBatch(t *testing.T) {
+	t.Parallel()
+
+	// A valid batch request.
+	const batch = `[
+		{ "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1 },
+		{ "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 2 },
+		{ "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 3 }
+	]`
+
+	r, w := io.Pipe() // Create a pipe to simulate a connection.
+
+	conn := newIOReadWriteCloser(strings.NewReader(batch), w)
+
+	s := jrpc.NewServer(nil)
+
+	go s.ServeConn(context.Background(), conn)
+
+	// Wait for the server to finish processing the request.
+	if err := json.NewDecoder(r).Decode(&[]any{}); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+}
+
+func TestServer_ServeConnInvalidBatch(t *testing.T) {
+	t.Parallel()
+
+	// An invalid batch request.
+	const batch = `[
+	  { "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1 },
+		"jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 2 }
+		]` // missing opening brace for second request.
+
+	r, w := io.Pipe() // Create a pipe to simulate a connection.
+
+	conn := newIOReadWriteCloser(strings.NewReader(batch), w)
+
+	testSucceedc := make(chan struct{}) // Expect request to fail.
+	testFailc := make(chan error)       // Test will fail if the request succeeds or an error occurs.
+
+	errorLog := func(string, ...any) {
+		testSucceedc <- struct{}{} // Error log should be called.
+	}
+
+	s := jrpc.NewServer(errorLog)
+
+	go s.ServeConn(context.Background(), conn)
+
+	go func() {
+		if err := json.NewDecoder(r).Decode(&[]any{}); err != nil {
+			testFailc <- err
+		}
+	}()
+
+	select {
+	case <-testSucceedc:
+	case err := <-testFailc:
+		t.Fatalf("expected invalid JSON: %v", err)
+	}
+}
+
+func TestServer_ServeConnValidSingle(t *testing.T) {
+	t.Parallel()
+
+	// A valid single request.
+	const request = `{"jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1}`
+
+	r, w := io.Pipe() // Create a pipe to simulate a connection.
+
+	conn := newIOReadWriteCloser(strings.NewReader(request), w)
+
+	s := jrpc.NewServer(nil)
+
+	go s.ServeConn(context.Background(), conn)
+
+	// Wait for the server to finish processing the request.
+	var res any
+	if err := json.NewDecoder(r).Decode(&res); err != nil {
+		t.Fatalf("expected valid JSON, got %v", err)
+	}
+}
+
+func TestServer_ServeConnInvalidSingle(t *testing.T) {
+	t.Parallel()
+
+	// An invalid single request.
+	const request = `{"jsonrpc": "2.0", "method": "foo", "params": , "id": 1}` // params have no value.
+
+	r, w := io.Pipe() // Create a pipe to simulate a connection.
+
+	conn := newIOReadWriteCloser(strings.NewReader(request), w)
+
+	testSucceedc := make(chan struct{}) // Expect request to fail.
+	testFailc := make(chan error)       // Test will fail if the request succeeds or an error occurs.
+
+	errorLog := func(string, ...any) {
+		testSucceedc <- struct{}{} // Error log should be called.
+	}
+
+	s := jrpc.NewServer(errorLog)
+
+	go s.ServeConn(context.Background(), conn)
+
+	go func() {
+		if err := json.NewDecoder(r).Decode(&struct{}{}); err != nil {
+			testFailc <- err
+		}
+	}()
+
+	select {
+	case <-testSucceedc:
+	case err := <-testFailc:
+		t.Fatalf("expected invalid JSON: %v", err)
+	}
+}
+
+func TestServer_ServeConnShouldCloseConn(t *testing.T) {
+	t.Parallel()
+
+	// A valid single request.
+	const request = `{"jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1}`
+
+	conn := newIOReadWriteCloser(strings.NewReader(request), io.Discard)
+
+	s := jrpc.NewServer(nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	s.ServeConn(ctx, conn)
+
+	if !conn.closed {
+		t.Fatalf("expected connection to be closed")
+	}
+}

--- a/server_test.go
+++ b/server_test.go
@@ -90,10 +90,9 @@ func TestServer_ServeConnInvalidBatch(t *testing.T) {
 
 	// An invalid batch request.
 	const batch = `[
-	  { "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1 },
-		"jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 2 }
-		]` // missing opening brace for second request.
-
+	  { "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 1 }
+	  { "jsonrpc": "2.0", "method": "foo", "params": [ "bar" ], "id": 2 }
+		]` // missing comma between the two requests.
 	r, w := io.Pipe() // Create a pipe to simulate a connection.
 
 	conn := newIOReadWriteCloser(strings.NewReader(batch), w)


### PR DESCRIPTION
## Changes
* Log errors to user provided log function.
* Make `Server.Accept` and `Server.ServeConn` take a context.
* Allow to `Response` to have a null ID for parse error responses.
* Implement `Server.ServeConn` and `Server.Accept`.