### PR TITLE
Refactor params package

### DIFF
--- a/parse/unmarshal.go
+++ b/parse/unmarshal.go
@@ -1,0 +1,127 @@
+package parse
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/kytnacode/go-jrpc/jsonutil"
+)
+
+var (
+	// ErrInvalidParams is returned when an error occurs while parsing the params.
+	ErrInvalidParams = errors.New("invalid params")
+)
+
+// Custom unmarshaler for the params.
+func (pw *paramsWrapper) UnmarshalJSON(b []byte) error {
+	// Trim left whitespace.
+	trimmed := jsonutil.TrimLeftWhitespace(b)
+	if len(trimmed) == 0 {
+		return fmt.Errorf("empty JSON: %w", ErrInvalidParams)
+	}
+
+	// Check if the params are an array or an object.
+	if trimmed[0] == '[' { // array
+		return pw.parsePositional(b)
+	} else if trimmed[0] == '{' { // object
+		return pw.parseNamed(b)
+	} else { // invalid
+		return fmt.Errorf("parameters must be an array or an object: %w", ErrInvalidParams)
+	}
+}
+
+// Params parses the params and returns the value of type T.
+// The params can be an array or an object.
+// If the params are an array, the fields of T must be in the same order as the elements of the array.
+// If the params are an object, the fields of T must have the same name as the keys of the object or have a json tag with the same name.
+// Only exported fields are considered.
+func Params[T any](params []byte) (T, error) {
+	t := reflect.TypeFor[T]()
+
+	v, err := ParamsType(t, params)
+	if err != nil {
+		zero, _ := v.(T) // Safe to convert.
+
+		return zero, err
+	}
+
+	value, _ := v.(T) // Safe to convert.
+
+	return value, nil
+}
+
+func ParamsType(t reflect.Type, params []byte) (any, error) {
+	if t.Kind() != reflect.Struct {
+		return reflect.Zero(t).Interface(), fmt.Errorf("params must be a struct: %w", ErrInvalidParams)
+	}
+
+	// Custom unmarshaler for the params.
+	pw := paramsWrapper{
+		t: t,
+	}
+
+	if err := json.Unmarshal(params, &pw); err != nil {
+		return reflect.Zero(t).Interface(), err
+	}
+
+	return pw.value, nil
+}
+
+// parsePositional parses the params when they are an array.
+func (pw *paramsWrapper) parsePositional(b []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(b))
+
+	// Start array.
+	_, err := dec.Token()
+	if err != nil {
+		return err
+	}
+
+	params := reflect.New(pw.t) // Output params.
+
+	for i := range pw.t.NumField() {
+		// Unmarshal the field.
+		field := reflect.New(pw.t.Field(i).Type)
+
+		if err := dec.Decode(field.Interface()); err != nil {
+			return err
+		}
+
+		// Set the field.
+		params.Elem().Field(i).Set(field.Elem())
+	}
+
+	if dec.More() {
+		return fmt.Errorf("extra parameters in array: %w", ErrInvalidParams)
+	}
+
+	pw.value = params.Elem().Interface()
+
+	// End array.
+	_, err = dec.Token()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// parseNamed parses params when they are an object.
+func (pw *paramsWrapper) parseNamed(b []byte) error {
+	params := reflect.New(pw.t) // Output params.
+
+	dec := json.NewDecoder(bytes.NewReader(b))
+	dec.DisallowUnknownFields()
+
+	// Unmarshal the object.
+	if err := dec.Decode(params.Interface()); err != nil {
+		return err
+	}
+
+	pw.value = params.Elem().Interface()
+
+	return nil
+}

--- a/parse/unmarshal_test.go
+++ b/parse/unmarshal_test.go
@@ -1,0 +1,235 @@
+package parse_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kytnacode/go-jrpc/parse"
+)
+
+type args struct {
+	Name   string `json:"name"`
+	Last   string `json:"last"`
+	Age    int    `json:"age"`
+	Nested nested `json:"nested"`
+}
+
+type nested struct {
+	Email string `json:"email"`
+}
+
+func TestParseParams_ValidParams(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params   []byte
+		expected args
+	}
+
+	const (
+		name  = "john"
+		last  = "doe"
+		age   = 30
+		email = "john.doe@example.com"
+	)
+
+	testData := map[string]data{
+		"array": {
+			params:   fmt.Appendf(nil, `["%v", "%v", %v, { "email": "%v" }]`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+		},
+		"object": {
+			params:   fmt.Appendf(nil, `{"name": "%v", "last": "%v", "age": %v, "nested": { "email": "%v" }}`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			got, err := parse.Params[args](data.params)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if got != data.expected {
+				t.Errorf("expected %v, got %v", data.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseParams_InvalidParams(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params []byte
+	}
+
+	const (
+		name  = "john"
+		last  = "doe"
+		age   = 30
+		email = "john.doe@example.com"
+	)
+
+	testData := map[string]data{
+		"empty": {
+			params: []byte{},
+		},
+		"invalid": {
+			params: []byte(`"invalid"`),
+		},
+		"extra parameters array": {
+			params: fmt.Appendf(nil, `["%v", "%v", %v, { "email": "%v" }, "extra"]`, name, last, age, email),
+		},
+		"extra parameters object": {
+			params: fmt.Appendf(nil, `{"name": "%v", "last": "%v", "age": %v, "nested": { "email": "%v" }, "extra": "extra"}`, name, last, age, email),
+		},
+		"unknown field": {
+			// Replace `name` field to not trigger extra parameters error, we want to test the unknown field error.
+			params: fmt.Appendf(nil, `{"unknown": "unknown", "last": "%v", "age": %v, "nested": { "email": "%v" }}`, last, age, email),
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse.Params[args](data.params)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseParamsType_InvalidType(t *testing.T) {
+	t.Parallel()
+
+	in := []byte(`{ "name": "john", "last": "doe", "age": 30, "nested": { "email": "john.doe@example.com" } }`)
+
+	type data struct {
+		t reflect.Type
+	}
+
+	testData := map[string]data{
+		"array": {
+			t: reflect.TypeFor[[]any](),
+		},
+		"channel": {
+			t: reflect.TypeFor[chan any](),
+		},
+		"func": {
+			t: reflect.TypeFor[func() any](),
+		},
+		"int": {
+			t: reflect.TypeFor[int](),
+		},
+		"map": {
+			t: reflect.TypeFor[map[string]any](),
+		},
+		"string": {
+			t: reflect.TypeFor[string](),
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse.ParamsType(data.t, in)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseParamsType_ValidParams(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params   []byte
+		t        reflect.Type
+		expected args
+	}
+
+	const (
+		name  = "john"
+		last  = "doe"
+		age   = 30
+		email = "john.doe@example.com"
+	)
+
+	testData := map[string]data{
+		"array": {
+			params:   fmt.Appendf(nil, `["%v", "%v", %v, { "email": "%v" }]`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+			t:        reflect.TypeFor[args](),
+		},
+		"object": {
+			params:   fmt.Appendf(nil, `{"name": "%v", "last": "%v", "age": %v, "nested": { "email": "%v" }}`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+			t:        reflect.TypeFor[args](),
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			got, err := parse.ParamsType(data.t, data.params)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if got != data.expected {
+				t.Errorf("expected %v, got %v", data.expected, got)
+			}
+		})
+	}
+}
+
+func TestParseParamsType_InvalidParams(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params []byte
+		t      reflect.Type
+	}
+
+	const (
+		name  = "john"
+		last  = "doe"
+		age   = 30
+		email = "john.doe@example.com"
+	)
+
+	testData := map[string]data{
+		"empty": {
+			params: []byte{},
+			t:      reflect.TypeFor[args](),
+		},
+		"invalid": {
+			params: []byte(`"invalid"`),
+			t:      reflect.TypeFor[args](),
+		},
+		"extra parameters array": {
+			params: fmt.Appendf(nil, `["%v", "%v", %v, { "email": "%v" }, "extra"]`, name, last, age, email),
+			t:      reflect.TypeFor[args](),
+		},
+		"extra parameters object": {
+			params: fmt.Appendf(nil, `{"name": "%v", "last": "%v", "age": %v, "nested": { "email": "%v" }, "extra": "extra"}`, name, last, age, email),
+			t:      reflect.TypeFor[args](),
+		},
+		"unknown field": {
+			// Replace `name` field to not trigger extra parameters error, we want to test the unknown field error.
+			params: fmt.Appendf(nil, `{"unknown": "unknown", "last": "%v", "age": %v, "nested": { "email": "%v" }}`, last, age, email),
+			t:      reflect.TypeFor[args](),
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse.ParamsType(data.t, data.params)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}

--- a/parse/wrapper.go
+++ b/parse/wrapper.go
@@ -1,0 +1,12 @@
+package parse
+
+import "reflect"
+
+// paramsWrapper is a wrapper for the params to be unmarshaled.
+// Implements the json.Unmarshaler interface.
+type paramsWrapper struct {
+	// t is the type of the params to be unmarshaled.
+	t reflect.Type
+	// value is the value of params after unmarshaling, it will be of type t.
+	value any
+}


### PR DESCRIPTION
## Changes
* Change `params` package name to `parse` to avoid naming conflicts with variables.
* Remove `Parse` prefix from `ParseParams` and `ParseParamsType`.
* Move `paramsWrapper.UnmarshalJSON` implementation before to `ParseParams`.