### PR TITLE
Allow to parse pointer args

### DIFF
--- a/parse/unmarshal.go
+++ b/parse/unmarshal.go
@@ -54,8 +54,9 @@ func Params[T any](params []byte) (T, error) {
 }
 
 func ParamsType(t reflect.Type, params []byte) (any, error) {
-	if t.Kind() != reflect.Struct {
-		return reflect.Zero(t).Interface(), fmt.Errorf("params must be a struct: %w", ErrInvalidParams)
+	// Check if the params are a struct or a pointer to a struct.
+	if t.Kind() != reflect.Struct && (t.Kind() != reflect.Pointer && t.Elem().Kind() != reflect.Struct) {
+		return reflect.Zero(t).Interface(), fmt.Errorf("params must be a struct or a pointer: %w", ErrInvalidParams)
 	}
 
 	// Custom unmarshaler for the params.
@@ -82,16 +83,30 @@ func (pw *paramsWrapper) parsePositional(b []byte) error {
 
 	params := reflect.New(pw.t) // Output params.
 
-	for i := range pw.t.NumField() {
+	var structT reflect.Type
+
+	// t is guaranteed to be a struct or a pointer to a struct.
+	if pw.t.Kind() == reflect.Struct {
+		structT = pw.t
+	} else { // Pointer to struct.
+		structT = pw.t.Elem()
+		params.Elem().Set(reflect.New(structT))
+	}
+
+	for i := range structT.NumField() {
 		// Unmarshal the field.
-		field := reflect.New(pw.t.Field(i).Type)
+		field := reflect.New(structT.Field(i).Type)
 
 		if err := dec.Decode(field.Interface()); err != nil {
 			return err
 		}
 
 		// Set the field.
-		params.Elem().Field(i).Set(field.Elem())
+		if params.Elem().Kind() == reflect.Struct { // Struct.
+			params.Elem().Field(i).Set(field.Elem())
+		} else { // Pointer to struct.
+			params.Elem().Elem().Field(i).Set(field.Elem())
+		}
 	}
 
 	if dec.More() {

--- a/parse/unmarshal.go
+++ b/parse/unmarshal.go
@@ -55,7 +55,7 @@ func Params[T any](params []byte) (T, error) {
 
 func ParamsType(t reflect.Type, params []byte) (any, error) {
 	// Check if the params are a struct or a pointer to a struct.
-	if t.Kind() != reflect.Struct && (t.Kind() != reflect.Pointer && t.Elem().Kind() != reflect.Struct) {
+	if t.Kind() != reflect.Struct && !(t.Kind() == reflect.Pointer && t.Elem().Kind() == reflect.Struct) {
 		return reflect.Zero(t).Interface(), fmt.Errorf("params must be a struct or a pointer: %w", ErrInvalidParams)
 	}
 

--- a/parse/unmarshal_test.go
+++ b/parse/unmarshal_test.go
@@ -273,3 +273,40 @@ func TestParseParamsType_InvalidParams(t *testing.T) {
 		})
 	}
 }
+
+func TestParseParamsType_NonStructOrPointerToStruct(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params []byte
+		t      reflect.Type
+	}
+
+	testData := map[string]data{
+		"int": {
+			params: []byte(`1`),
+			t:      reflect.TypeFor[int](),
+		},
+		"string": {
+			params: []byte(`"string"`),
+			t:      reflect.TypeFor[string](),
+		},
+		"array": {
+			params: []byte(`["hello", "world"]`),
+			t:      reflect.TypeFor[[]string](),
+		},
+		"object": {
+			params: []byte(`{ "hello": "world" }`),
+			t:      reflect.TypeFor[map[string]string](),
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse.ParamsType(data.t, data.params)
+			if err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}

--- a/parse/unmarshal_test.go
+++ b/parse/unmarshal_test.go
@@ -59,6 +59,46 @@ func TestParseParams_ValidParams(t *testing.T) {
 	}
 }
 
+func TestParseParams_ValidPointerParams(t *testing.T) {
+	t.Parallel()
+
+	type data struct {
+		params   []byte
+		expected args
+	}
+
+	const (
+		name  = "john"
+		last  = "doe"
+		age   = 30
+		email = "john.doe@example.com"
+	)
+
+	testData := map[string]data{
+		"array": {
+			params:   fmt.Appendf(nil, `["%v", "%v", %v, { "email": "%v" }]`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+		},
+		"object": {
+			params:   fmt.Appendf(nil, `{"name": "%v", "last": "%v", "age": %v, "nested": { "email": "%v" }}`, name, last, age, email),
+			expected: args{Name: name, Last: last, Age: age, Nested: nested{Email: email}},
+		},
+	}
+
+	for name, data := range testData {
+		t.Run(name, func(t *testing.T) {
+			got, err := parse.Params[*args](data.params)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+
+			if *got != data.expected {
+				t.Errorf("expected %v, got %v", data.expected, got)
+			}
+		})
+	}
+}
+
 func TestParseParams_InvalidParams(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
# Changes
* Allow `parse.Params` and `parse.ParamsType` to parse a pointer as arguments.