### PR TITLE
Soft go requirement from 1.24.1 to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/kytnacode/go-jrpc
 
-go 1.24.1
+go 1.22
 
 retract [v0.1.0, v0.1.2]


### PR DESCRIPTION
## Changes
* Soft go requirement from 1.24.1 to 1.22.