### PR TITLE
Ensure sever concurrent use safeness

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -701,7 +701,7 @@ func TestServer_AcceptShouldBeSafeForConcurrentUse(t *testing.T) {
 	}
 }
 
-func TestServerShouldServerOverHTTPAndConnectionAndListenerConcurrenlty(t *testing.T) {
+func TestServerShouldServeOverHTTPAndConnectionAndListenerConcurrently(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Changes
* Add tests to ensure `jrpc.Server` is safe for concurrent use.