### PR TITLE
Fix client call blocking forever on notification

### DIFF
--- a/client.go
+++ b/client.go
@@ -229,6 +229,8 @@ func (c *Client) Go(done chan *CallState, data *CallData) *CallState {
 	}
 
 	if data.notify {
+		call.Done <- call // Notification, no need to wait for the response.
+
 		return call // Notification, no need to store the call.
 	}
 


### PR DESCRIPTION
## Changes
- Fix client blocking forever on `Client.Call` with a notification.
- Add tests for `Client.Call`.