### PR TITLE
Fix/client tests blocking on connection close

### DIFF
--- a/client.go
+++ b/client.go
@@ -224,7 +224,7 @@ func (c *Client) Go(done chan *CallState, data *CallData) *CallState {
 		params, err := json.Marshal(data.args)
 		if err != nil {
 			call.Error = err
-			done <- call
+			call.Done <- call
 
 			return call
 		}
@@ -258,6 +258,10 @@ func (c *Client) Go(done chan *CallState, data *CallData) *CallState {
 		delete(c.pending, seq) // Remove the call from the pending map.
 
 		return call
+	}
+
+	if data.notify {
+		call.Done <- call
 	}
 
 	return call

--- a/client.go
+++ b/client.go
@@ -233,9 +233,7 @@ func (c *Client) Go(done chan *CallState, data *CallData) *CallState {
 		*req.Params = json.RawMessage(params)
 	}
 
-	if data.notify {
-		call.Done <- call
-	} else {
+	if !data.notify {
 		// Store the call in the pending map.
 		c.pendingMu.Lock()
 		defer c.pendingMu.Unlock()
@@ -411,9 +409,7 @@ func (c *Client) Input(ctx context.Context, errCh chan error) {
 			err = fmt.Errorf("context cancelled: %w", ctx.Err())
 		default:
 			if err = c.dec.Decode(&m); err != nil {
-				if !errors.Is(err, io.EOF) {
-					errCh <- fmt.Errorf("failed to decode message: %w", err)
-				}
+				errCh <- fmt.Errorf("failed to decode message: %w", err)
 
 				continue
 			}
@@ -466,6 +462,8 @@ func (c *Client) Input(ctx context.Context, errCh chan error) {
 
 					call, ok := c.pending[*batchID]
 					if !ok {
+						c.pendingMu.Unlock()
+
 						continue
 					}
 
@@ -478,6 +476,8 @@ func (c *Client) Input(ctx context.Context, errCh chan error) {
 					for id := range call.ids {
 						delete(c.pending, id)
 					}
+
+					c.pendingMu.Unlock()
 				}
 
 				if missing {

--- a/internal/test/doc.go
+++ b/internal/test/doc.go
@@ -1,0 +1,2 @@
+// Package test provides utils for testing.
+package test

--- a/internal/test/reader.go
+++ b/internal/test/reader.go
@@ -1,0 +1,9 @@
+package test
+
+// NoOpReader is a no-op reader that does nothing when reading. Never return EOF nor other errors.
+type NoOpReader struct{}
+
+// Read implements the io.Reader interface, always returning 0 bytes read and nil error.
+func (r *NoOpReader) Read(_ []byte) (n int, err error) {
+	return 0, nil
+}


### PR DESCRIPTION
## Changes
- Ensure finish calls in `Client.Go`
- Add `test.NoOpReader`
- Fix clients tests blocking on closing connection.