### PR TITLE
Fix/server linting and test typo

### DIFF
--- a/server.go
+++ b/server.go
@@ -99,8 +99,8 @@ func WithLogger(logger func(string, ...any)) func(*Server) {
 	}
 }
 
-// Register registers a method with the given name and handler. If the default [MethodRegister] is used, the handler must
-// meet the criteria defined on [Registry]. Different registries may have different criteria.
+// Register registers a method with the given name and handler. If the default [MethodRegister] is used, the handler
+// must meet the criteria defined on [Registry]. Different registries may have different criteria.
 //
 // Implements the [Register] interface.
 // Is safe for concurrent use.

--- a/server.go
+++ b/server.go
@@ -159,7 +159,11 @@ func (s *Server) ServeConn(ctx context.Context, conn io.ReadWriteCloser) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	defer conn.Close()
+	defer func() {
+		if err := conn.Close(); err != nil {
+			s.errorLog("failed to close connection: %v", err)
+		}
+	}()
 
 	dec := json.NewDecoder(conn)
 	enc := json.NewEncoder(conn)

--- a/server_test.go
+++ b/server_test.go
@@ -716,7 +716,7 @@ func TestServer_AcceptShouldBeSafeForConcurrentUse(t *testing.T) {
 	}
 }
 
-func TestServerShouldServeOverHTTPAndConnectionAndListenerConcurrently(t *testing.T) {
+func TestServer_ShouldServeOverHTTPAndConnectionAndListenerConcurrently(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
## Changes
- Change `TestServerShouldServeOverHTTPAndConnectionAndListenerConcurrently` test name to `TestServer_ShouldServeOverHTTPAndConnectionAndListenerConcurrently`.
- Fix comment line with a width of 121.
- Check connection close error on `Server.ServeConn`.